### PR TITLE
ci: Add workflow to publish Docker image on master push

### DIFF
--- a/.github/workflows/master-docker-publish.yml
+++ b/.github/workflows/master-docker-publish.yml
@@ -1,0 +1,31 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/team_task_manager:latest


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the process of building and publishing a Docker image.

The workflow is triggered on every push to the `master` branch. It builds the Docker image from the project's Dockerfile and publishes it to a container registry, ensuring an up-to-date image is always available for deployment.